### PR TITLE
Prefer system font over custom font-face

### DIFF
--- a/src/assets/styles/base/_fonts.postcss
+++ b/src/assets/styles/base/_fonts.postcss
@@ -1,5 +1,5 @@
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: normal;
   font-weight: normal;
   src:
@@ -7,7 +7,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: italic;
   font-weight: normal;
   src:
@@ -15,7 +15,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: normal;
   font-weight: 500;
   src:
@@ -23,7 +23,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: normal;
   font-weight: 700;
   src:
@@ -31,7 +31,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: italic;
   font-weight: 700;
   src:
@@ -39,7 +39,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: normal;
   font-weight: 300;
   src:
@@ -47,7 +47,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: italic;
   font-weight: 300;
   src:
@@ -55,7 +55,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: normal;
   font-weight: 100;
   src:
@@ -63,7 +63,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue';
+  font-family: 'HelveticaNeue';
   font-style: italic;
   font-weight: 100;
   src:
@@ -71,7 +71,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue Condensed';
+  font-family: 'HelveticaNeueCondensed';
   font-style: normal;
   font-weight: 700;
   src:
@@ -79,7 +79,7 @@
 }
 
 @font-face {
-  font-family: 'Helvetica Neue Condensed';
+  font-family: 'HelveticaNeueCondensed';
   font-style: normal;
   font-weight: 900;
   src:

--- a/src/assets/styles/main.postcss
+++ b/src/assets/styles/main.postcss
@@ -18,13 +18,14 @@
 }
 
 :root {
-  --fontFamily: 'Helvetica Neue', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Hiragino Kaku Gothic Pro', 'Meiryo', 'Malgun Gothic', sans-serif;
-  --fontFamilyCondensed: 'Helvetica Neue Condensed', 'Helvetica Neue', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Hiragino Kaku Gothic Pro', 'Meiryo', 'Malgun Gothic', sans-serif;
+  --fontFamily: 'Helvetica Neue', HelveticaNeue, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Hiragino Kaku Gothic Pro', Meiryo, 'Malgun Gothic', Verdana, Geneva, sans-serif;
+  --fontFamilyCondensed: 'Helvetica Neue Condensed', HelveticaNeueCondensed, 'Helvetica Neue', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Hiragino Kaku Gothic Pro', Meiryo, 'Malgun Gothic', Verdana, Geneva, sans-serif;
   --fontSizeBase: 1em;
   --fontSizePageHeader: 1.5em;
   --fontSizePageSubheader: 1.125em;
   --fontSizeSectionHeader: 0.875em;
   --fontSizeInput: 0.875em;
+
 }
 
 :root {


### PR DESCRIPTION
"Helvetica Neue" is not available by default on Windows, so we'll want to use our custom font-face there. On macOS we can use the system font.