### PR TITLE
Error page breadcrumbs

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -9,7 +9,6 @@ import testClass from 'domain/testClass';
 import Breadcrumbs from 'components/Breadcrumbs';
 import HistoryLink from 'components/HistoryLink';
 import connect from 'domain/connect';
-import ApiCall from 'containers/ApiCalls';
 import PerformanceProfiler from 'components/PerformanceProfiler';
 import Config from 'domain/Config';
 import BreadcrumbsBuilder from 'domain/BreadcrumbsBuilder';
@@ -72,18 +71,15 @@ class App extends PureComponent {
             onExpand={(e) => this._expandSidebar(e)}
             onCollapse={(e) => this._collapseSidebar(e)} />
         <div className={styles.App_content}>
-          {
-            ! this.props.isThereAnError &&
-            <div className={styles.App_content_auxiliary}>
-              {
-                this._breadcrumbs &&
-                <Breadcrumbs className={styles.App_content_auxiliary_breadcrumbs}
-                    items={this._breadcrumbs}
-                    singleLineMode />
-              }
-              <HistoryLink className={styles.App_content_auxiliary_historyLink} {...this.props} />
-            </div>
-          }
+          <div className={styles.App_content_auxiliary}>
+            {
+              this._breadcrumbs &&
+              <Breadcrumbs className={styles.App_content_auxiliary_breadcrumbs}
+                  items={this._breadcrumbs}
+                  singleLineMode />
+            }
+            <HistoryLink className={styles.App_content_auxiliary_historyLink} {...this.props} />
+          </div>
           <div className={styles.App_content_wrap}>{this.props.children}</div>
         </div>
       </div>
@@ -94,11 +90,6 @@ class App extends PureComponent {
 
 App.propTypes = {
   children: PropTypes.node,
-  isThereAnError: PropTypes.bool.isRequired,
 };
 
-export function mapStateToProps(state) {
-  return { isThereAnError: ApiCall.getErrors(state).size > 0 };
-}
-
-export default connect(mapStateToProps)(App);
+export default connect()(App);

--- a/src/components/Breadcrumbs/index.jsx
+++ b/src/components/Breadcrumbs/index.jsx
@@ -183,7 +183,7 @@ Breadcrumbs.propTypes = {
     label: PropTypes.string.isRequired,
     href: PropTypes.string.isRequired,
     clickable: PropTypes.bool.isRequired,
-    backLinkHref: PropTypes.string.isRequired,  // it's an override
+    backLinkHref: PropTypes.string,  // it's an override
   })).isRequired,
   singleLineMode: PropTypes.bool,
   router: PropTypes.shape({

--- a/src/containers/ErrorPageHandler/index.jsx
+++ b/src/containers/ErrorPageHandler/index.jsx
@@ -1,64 +1,42 @@
 import styles from './style.postcss';
-import React from 'react';
-import pure from 'recompose/pure';
+
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import is from 'is_js';
 import ErrorPage from 'components/ErrorPage';
 import connect from 'domain/connect';
 import ApiCall from 'containers/ApiCalls';
 import ErrorPageConfig from 'domain/ErrorPageConfig';
-import is from 'is_js';
 import AlertDialog from 'components/AlertDialog';
 import ErrorMessage from 'domain/ErrorMessage';
 import Config from 'domain/Config';
 import userManager from 'containers/SingleSignOn/userManager';
-import PropTypes from 'prop-types';
 
-export const ErrorPageHandler = (props) => {
-  const { children, config, erroredApis, erroredApi, clean } = props;
-  const cleanErrors = () => erroredApis.forEach((api) => clean(api.id));
-
-  return <div className={styles.ErrorPageHandler}>
-    {renderError()}
-    {renderChildren()}
-  </div>;
-
-  function renderError() {
-    if (! erroredApi) {
-      return null;
-    }
-
-    if (erroredApi.error && erroredApi.error.status === 401) {
-      setLastUrlPath();
-      userManager.forceSignoutRedirect();
-      throw new Error('Api called with 401 unauthorized');
-    }
-
-    if (shouldShowPopUp()) {
-      const { response } = erroredApi.error;
-      return <AlertDialog isWarning
-          content1={buildMessage(response)}
-          okButtonContent="OK"
-          onButtonClick={cleanErrors} />;
-    }
-
-    return <ErrorPage erroredApi={erroredApi}
-        config={config}
-        afterButtonClicked={cleanErrors}
-        {...props} />;
+export class ErrorPageHandler extends PureComponent {
+  constructor(props) {
+    super(props);
+    this._setLastUrlPath = this._setLastUrlPath.bind(this);
+    this._shouldShowPopUp = this._shouldShowPopUp.bind(this);
+    this._buildMessage = this._buildMessage.bind(this);
+    this._cleanErrors = this._cleanErrors.bind(this);
+    this._renderChildren = this._renderChildren.bind(this);
+    this._renderError = this._renderError.bind(this);
   }
 
-  function setLastUrlPath() {
+  componentWillUpdate({ location: { pathname: nextPath } }) {
+    const { location: { pathname } } = this.props;
+    if (pathname !== nextPath) {  // page changed, clear errors
+      this._cleanErrors();
+    }
+  }
+
+  _setLastUrlPath() {
     sessionStorage.lastUrlPath = location.pathname + location.search;
   }
 
-  function renderChildren() {
-    if (erroredApi && ! shouldShowPopUp()) {
-      return null; // Because the error page will be rendered.
-    }
+  _shouldShowPopUp() {
+    const { erroredApi } = this.props;
 
-    return children;
-  }
-
-  function shouldShowPopUp() {
     if (Config.get('errorHandlerRendersPopUps') !== true || ! erroredApi) {
       return false;
     }
@@ -67,7 +45,9 @@ export const ErrorPageHandler = (props) => {
     return is.object(response) && status !== 500;
   }
 
-  function buildMessage(response) {
+  _buildMessage() {
+    const { erroredApi: { error: { response } } } = this.props;
+
     let message = ErrorMessage.for(response.errorCode) || response.message;
 
     // To handle the pattern of exception response from the end point of identity server
@@ -87,15 +67,75 @@ export const ErrorPageHandler = (props) => {
 
     return message;
   }
-};
+
+  _cleanErrors() {
+    const { erroredApis, clean } = this.props;
+    erroredApis.forEach((api) => clean(api.id));
+  }
+
+  _renderChildren() {
+    const { erroredApi, children } = this.props;
+
+    if (erroredApi && ! this._shouldShowPopUp()) {
+      return null; // Because the error page will be rendered.
+    }
+
+    return children;
+  }
+
+  _renderError() {
+    const { erroredApi, config } = this.props;
+
+    if (! erroredApi) {
+      return null;
+    }
+
+    if (erroredApi.error && erroredApi.error.status === 401) {
+      this._setLastUrlPath();
+      userManager.forceSignoutRedirect();
+      throw new Error('Api called with 401 unauthorized');
+    }
+
+    if (this._shouldShowPopUp()) {
+      return <AlertDialog isWarning
+          content1={this._buildMessage()}
+          okButtonContent="OK"
+          onButtonClick={this._cleanErrors} />;
+    }
+
+    return <ErrorPage erroredApi={erroredApi}
+        config={config}
+        afterButtonClicked={this._cleanErrors}
+        {...this.props} />;
+  }
+
+  render() {
+    return <div className={styles.ErrorPageHandler}>
+      {this._renderError()}
+      {this._renderChildren()}
+    </div>;
+  }
+}
 
 ErrorPageHandler.propTypes = {
-  children: PropTypes.node,
-  replace: PropTypes.func.isRequired,
-  clean: PropTypes.func.isRequired,
-  erroredApis: PropTypes.object,
-  erroredApi: PropTypes.object,
   config: PropTypes.object,
+  erroredApis: PropTypes.shape({
+    size: PropTypes.string.func,
+    first: PropTypes.string.func,
+    forEach: PropTypes.string.func,
+  }),
+  erroredApi: PropTypes.shape({
+    error: PropTypes.shape({
+      status: PropTypes.number,
+      response: PropTypes.any,
+    }),
+  }),
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+  clean: PropTypes.func.isRequired,
+  replace: PropTypes.func.isRequired,
+  children: PropTypes.node,
 };
 
 export function mapStateToProps(state, { routes }) {
@@ -120,4 +160,4 @@ function getApiError(erroredApis) {
   return erroredApis.first();
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(pure(ErrorPageHandler));
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorPageHandler);


### PR DESCRIPTION
The revamped error page clears out errors when `location.pathname` changes (this happens in `componentWillUpdate`)