### PR TITLE
Implemented buildRoute() without using path module

### DIFF
--- a/src/domain/createBuildRoute/index.js
+++ b/src/domain/createBuildRoute/index.js
@@ -43,8 +43,8 @@ function getParams(args) {
 }
 
 function normalizeUrl(url) {
-  let result = url.replace(/[^:]\/\//g, '/');
-  while (true) {
+  let result = url.replace(/[^:]\/\//g, '/'); // Gets rid of duplicated slashes (//)
+  while (true) { // Interprets two dots (..), going up in the path for each occurrence
     const newResult = result.replace(/[a-z0-9]*\/\.\.\/?/gi, '');
     if (result === newResult) {
       break;
@@ -52,7 +52,7 @@ function normalizeUrl(url) {
 
     result = newResult;
   }
-  result = result.replace(/\.\//g, '');
+  result = result.replace(/\.\//g, ''); // Gets rid of ./
 
   return result;
 }

--- a/src/domain/createBuildRoute/index.js
+++ b/src/domain/createBuildRoute/index.js
@@ -43,9 +43,9 @@ function getParams(args) {
 }
 
 export function normalizeUrl(url) {
-  let result = url.replace(/(^|[a-z0-9])\/+/gi, '$1/'); // Gets rid of duplicated slashes (//)
+  let result = url.replace(/(^|[\w-])\/+/gi, '$1/'); // Gets rid of duplicated slashes (//)
   while (true) { // Interprets two dots (..), going up in the path for each occurrence
-    const newResult = result.replace(/((^\/)|[a-z0-9]*\/)\.\.\/?/gi, '$2');
+    const newResult = result.replace(/((^\/)|[\w-]*\/)\.\.\/?/gi, '$2');
     if (result === newResult) {
       break;
     }

--- a/src/domain/createBuildRoute/index.js
+++ b/src/domain/createBuildRoute/index.js
@@ -42,10 +42,10 @@ function getParams(args) {
   return undefined;
 }
 
-function normalizeUrl(url) {
-  let result = url.replace(/[^:]\/\//g, '/'); // Gets rid of duplicated slashes (//)
+export function normalizeUrl(url) {
+  let result = url.replace(/(^|[a-z0-9])\/+/gi, '$1/'); // Gets rid of duplicated slashes (//)
   while (true) { // Interprets two dots (..), going up in the path for each occurrence
-    const newResult = result.replace(/[a-z0-9]*\/\.\.\/?/gi, '');
+    const newResult = result.replace(/((^\/)|[a-z0-9]*\/)\.\.\/?/gi, '$2');
     if (result === newResult) {
       break;
     }

--- a/src/domain/createBuildRoute/index.js
+++ b/src/domain/createBuildRoute/index.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import is from 'is_js';
 
 import { formatPattern } from 'react-router';
@@ -7,7 +6,7 @@ export const createBuildRoute = (ownProps) => (...args) => {
   const route = getRoute(args);
   const params = getParams(args);
   if (is.not.object(params) || is.empty(params)) {
-    return path.resolve(ownProps.location.pathname, route);
+    return normalizeUrl(`/${ownProps.location.pathname}/${route}`);
   }
 
   let newRoute = '';
@@ -16,10 +15,10 @@ export const createBuildRoute = (ownProps) => (...args) => {
       return;
     }
 
-    newRoute = path.join(newRoute, routePiece.path);
+    newRoute = `${newRoute}/${routePiece.path}`;
   });
 
-  newRoute = path.resolve(newRoute, route);
+  newRoute = normalizeUrl(`/${newRoute}/${route}`);
 
   const finalParams = Object.assign({}, ownProps.params, params);
   newRoute = formatPattern(newRoute, finalParams);
@@ -41,6 +40,21 @@ function getParams(args) {
   }
 
   return undefined;
+}
+
+function normalizeUrl(url) {
+  let result = url.replace(/[^:]\/\//g, '/');
+  while (true) {
+    const newResult = result.replace(/[a-z0-9]*\/\.\.\/?/gi, '');
+    if (result === newResult) {
+      break;
+    }
+
+    result = newResult;
+  }
+  result = result.replace(/\.\//g, '');
+
+  return result;
 }
 
 export default createBuildRoute;

--- a/src/domain/createBuildRoute/spec.js
+++ b/src/domain/createBuildRoute/spec.js
@@ -147,11 +147,17 @@ describe('normalizeUrl()', () => {
   test('removes duplicated slashes', () => {
     expect(normalizeUrl('/test//path')).toMatch('/test/path');
     expect(normalizeUrl('/test///path')).toMatch('/test/path');
+    expect(normalizeUrl('/test_///path')).toMatch('/test_/path');
+    expect(normalizeUrl('/test9///path')).toMatch('/test9/path');
+    expect(normalizeUrl('/test-///path')).toMatch('/test-/path');
   });
 
   test('resolves two dots going up one level', () => {
     expect(normalizeUrl('/test/../path')).toMatch('/path');
     expect(normalizeUrl('/test/path/..')).toMatch('/test');
+    expect(normalizeUrl('/test/path9/..')).toMatch('/test');
+    expect(normalizeUrl('/test/path_/..')).toMatch('/test');
+    expect(normalizeUrl('/test/path-/..')).toMatch('/test');
     expect(normalizeUrl('/test/sublevel/../path')).toMatch('/test/path');
     expect(normalizeUrl('/../test/path')).toMatch('/test/path');
   });

--- a/src/domain/createBuildRoute/spec.js
+++ b/src/domain/createBuildRoute/spec.js
@@ -1,4 +1,4 @@
-import { createBuildRoute } from './';
+import { createBuildRoute, normalizeUrl } from './';
 
 test('is a function', () => {
   expect(typeof createBuildRoute).toBe('function');
@@ -136,5 +136,31 @@ describe('buildRoute', () => {
         expect(() => buildRoute({ mode: 'marking' })).toThrowError();
       });
     });
+  });
+});
+
+describe('normalizeUrl()', () => {
+  test('supports file:// protocol', () => {
+    expect(normalizeUrl('file:///test/path')).toMatch('file:///test/path');
+  });
+
+  test('removes duplicated slashes', () => {
+    expect(normalizeUrl('/test//path')).toMatch('/test/path');
+    expect(normalizeUrl('/test///path')).toMatch('/test/path');
+  });
+
+  test('resolves two dots going up one level', () => {
+    expect(normalizeUrl('/test/../path')).toMatch('/path');
+    expect(normalizeUrl('/test/path/..')).toMatch('/test');
+    expect(normalizeUrl('/test/sublevel/../path')).toMatch('/test/path');
+    expect(normalizeUrl('/../test/path')).toMatch('/test/path');
+  });
+
+  test('gets rid of "." items', () => {
+    expect(normalizeUrl('/test/./path')).toMatch('/test/path');
+    expect(normalizeUrl('/test/path/.')).toMatch('/test/path');
+    expect(normalizeUrl('/./test/path')).toMatch('/test/path');
+    expect(normalizeUrl('./test/path')).toMatch('test/path');
+    expect(normalizeUrl('./test/././path')).toMatch('test/path');
   });
 });

--- a/src/domain/createBuildRoute/spec.js
+++ b/src/domain/createBuildRoute/spec.js
@@ -18,6 +18,7 @@ describe('buildRoute', () => {
   test('interprets ../ in the route', () => {
     const ownProps = { location: { pathname: 'old/path/name' } };
     const buildRoute = createBuildRoute(ownProps);
+    expect(buildRoute('..')).toMatch('/old/path');
     expect(buildRoute('../newroute')).toMatch('/old/path/newroute');
     expect(buildRoute('../../newroute')).toMatch('/old/newroute');
     expect(buildRoute('../useless/../route')).toMatch('/old/path/route');


### PR DESCRIPTION
`buildRoute()` doesn't depend on the `path` NodeJS module, using instead regular expressions to get the same functionality.