### PR TITLE
The property “withSeparatorLine” is now <StudentCard.Content />’s responsibility

### DIFF
--- a/src/components/StudentCard/Content/index.jsx
+++ b/src/components/StudentCard/Content/index.jsx
@@ -4,14 +4,18 @@ import pure from 'recompose/pure';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const Content = ({ withSeparatorLine, children }) => {
+const Content = ({ children }, { withSeparatorLine }) => {
   const classes = classnames(styles.Content, { [styles.__withSeparatorLine]: withSeparatorLine });
   return <div className={classes}>{children}</div>;
 };
 
 Content.propTypes = {
-  withSeparatorLine: PropTypes.bool,
   children: PropTypes.node,
 };
+
+Content.contextTypes = {
+  withSeparatorLine: PropTypes.bool,
+};
+
 
 export default pure(Content);

--- a/src/components/StudentCard/Content/index.jsx
+++ b/src/components/StudentCard/Content/index.jsx
@@ -1,10 +1,16 @@
+import styles from './style.postcss';
 import React from 'react';
 import pure from 'recompose/pure';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
-const Content = (props) => <div>{props.children}</div>;
+const Content = ({ withSeparatorLine, children }) => {
+  const classes = classnames(styles.Content, { [styles.__withSeparatorLine]: withSeparatorLine });
+  return <div className={classes}>{children}</div>;
+};
 
 Content.propTypes = {
+  withSeparatorLine: PropTypes.bool,
   children: PropTypes.node,
 };
 

--- a/src/components/StudentCard/Content/spec.jsx
+++ b/src/components/StudentCard/Content/spec.jsx
@@ -1,7 +1,8 @@
 import styles from './style.postcss';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Content from './';
+import StudentCard from 'components/StudentCard';
 
 test('renders its children', () => {
   const wrapper = shallow(<Content><div id="innerContent" /></Content>);
@@ -9,6 +10,6 @@ test('renders its children', () => {
 });
 
 test('renders a StudentCard.Content with separator class (withSeparatorLine provided)', () => {
-  const wrapper = shallow(<Content withSeparatorLine />);
-  expect(wrapper.html()).toContain(styles.__withSeparatorLine);
+  const wrapper = mount(<StudentCard withSeparatorLine><Content /></StudentCard>);
+  expect(wrapper.find(Content).hasClass(styles.__withSeparatorLine)).toBe(true);
 });

--- a/src/components/StudentCard/Content/spec.jsx
+++ b/src/components/StudentCard/Content/spec.jsx
@@ -1,3 +1,4 @@
+import styles from './style.postcss';
 import React from 'react';
 import { shallow } from 'enzyme';
 import Content from './';
@@ -5,4 +6,9 @@ import Content from './';
 test('renders its children', () => {
   const wrapper = shallow(<Content><div id="innerContent" /></Content>);
   expect(wrapper.contains(<div id="innerContent" />)).toBe(true);
+});
+
+test('renders a StudentCard.Content with separator class (withSeparatorLine provided)', () => {
+  const wrapper = shallow(<Content withSeparatorLine />);
+  expect(wrapper.html()).toContain(styles.__withSeparatorLine);
 });

--- a/src/components/StudentCard/Content/style.postcss
+++ b/src/components/StudentCard/Content/style.postcss
@@ -1,0 +1,12 @@
+@import 'main.postcss';
+
+.Content {
+  &.__withSeparatorLine {
+    &::before {
+      border-top: 1px solid var(--colorBorder);
+      content: '';
+      display: block;
+      margin: 0 var(--cardContentPaddingHorizontal);
+    }
+  }
+}

--- a/src/components/StudentCard/Person/index.jsx
+++ b/src/components/StudentCard/Person/index.jsx
@@ -11,7 +11,6 @@ import ProductionStatus from 'components/ProductionStatus';
 const PersonComp = (props) => {
   const classes = classnames(styles.Person,
       styles.__1, {
-        [styles.__separated]: props.withSeparatorLine,
         [styles.__backgroundless]: props.backgroundless,
         [styles.__vertical]: props.vertical,
       }, props.className);
@@ -44,7 +43,6 @@ PersonComp.propTypes = {
   backgroundless: PropTypes.bool,
   vertical: PropTypes.bool,
   withBiggerAvatar: PropTypes.bool,
-  withSeparatorLine: PropTypes.bool,
 };
 
 export default pure(PersonComp);

--- a/src/components/StudentCard/Person/style.postcss
+++ b/src/components/StudentCard/Person/style.postcss
@@ -17,10 +17,6 @@
     background-color: var(--colorCardBg);
   }
 
-  &.__separated {
-    border-bottom: var(--hairThin) solid #e9e9e9;
-  }
-
   &.__vertical {
     flex-direction: column;
     padding-bottom: 5px;

--- a/src/components/StudentCard/Profile/index.jsx
+++ b/src/components/StudentCard/Profile/index.jsx
@@ -9,7 +9,7 @@ import Card from 'components/Card';
 import testClass from 'domain/testClass';
 import StudentCard from '../';
 
-const Profile = (props, { withSeparatorLine, backgroundless, vertical }) => {
+const Profile = (props, { backgroundless, vertical }) => {
   const { status, statusHighlighted } = props;
 
   const renderName = (prop, name, nameClasses, nameLink) => {
@@ -50,7 +50,6 @@ const Profile = (props, { withSeparatorLine, backgroundless, vertical }) => {
         backgroundless={backgroundless}
         vertical={vertical}
         withBiggerAvatar={props.withBiggerAvatar}
-        withSeparatorLine={withSeparatorLine}
         productionStatusClassName={testClass('studentCard-status')}
         productionStatus={status}
         productionStatusHighlighted={statusHighlighted} />
@@ -59,7 +58,6 @@ const Profile = (props, { withSeparatorLine, backgroundless, vertical }) => {
 
 Profile.contextTypes = {
   backgroundless: PropTypes.bool,
-  withSeparatorLine: PropTypes.bool,
   vertical: PropTypes.bool,
 };
 

--- a/src/components/StudentCard/StudentCard/index.jsx
+++ b/src/components/StudentCard/StudentCard/index.jsx
@@ -7,8 +7,8 @@ import PropTypes from 'prop-types';
 
 class StudentCard extends PureComponent {
   getChildContext() {
-    const { backgroundless = false, vertical = false } = this.props;
-    return { backgroundless, vertical };
+    const { backgroundless = false, withSeparatorLine = false, vertical = false } = this.props;
+    return { backgroundless, withSeparatorLine, vertical };
   }
 
   render() {
@@ -31,6 +31,7 @@ StudentCard.accentColors = ['grey', 'green', 'amber', 'red', 'invalid'];
 
 StudentCard.childContextTypes = {
   backgroundless: PropTypes.bool,
+  withSeparatorLine: PropTypes.bool,
   vertical: PropTypes.bool,
 };
 
@@ -38,6 +39,7 @@ StudentCard.propTypes = {
   backgroundless: PropTypes.bool,
   borderless: PropTypes.bool,
   className: PropTypes.string,
+  withSeparatorLine: PropTypes.bool,
   statusAccentPosition: PropTypes.oneOf(StudentCard.accentPosition),
   statusAccentColor: PropTypes.oneOf(StudentCard.accentColors),
   children: PropTypes.node,

--- a/src/components/StudentCard/StudentCard/index.jsx
+++ b/src/components/StudentCard/StudentCard/index.jsx
@@ -7,16 +7,8 @@ import PropTypes from 'prop-types';
 
 class StudentCard extends PureComponent {
   getChildContext() {
-    const {
-      backgroundless = false,
-      withSeparatorLine = false,
-      vertical = false,
-    } = this.props;
-    return {
-      backgroundless,
-      withSeparatorLine,
-      vertical,
-    };
+    const { backgroundless = false, vertical = false } = this.props;
+    return { backgroundless, vertical };
   }
 
   render() {
@@ -39,7 +31,6 @@ StudentCard.accentColors = ['grey', 'green', 'amber', 'red', 'invalid'];
 
 StudentCard.childContextTypes = {
   backgroundless: PropTypes.bool,
-  withSeparatorLine: PropTypes.bool,
   vertical: PropTypes.bool,
 };
 
@@ -47,7 +38,6 @@ StudentCard.propTypes = {
   backgroundless: PropTypes.bool,
   borderless: PropTypes.bool,
   className: PropTypes.string,
-  withSeparatorLine: PropTypes.bool,
   statusAccentPosition: PropTypes.oneOf(StudentCard.accentPosition),
   statusAccentColor: PropTypes.oneOf(StudentCard.accentColors),
   children: PropTypes.node,

--- a/src/components/StudentCard/StudentCard/spec.jsx
+++ b/src/components/StudentCard/StudentCard/spec.jsx
@@ -41,8 +41,3 @@ test('renders a StudentCard.Profile without separator class by default', () => {
   const wrapper = mount(<StudentCard><StudentCard.Profile /></StudentCard>);
   expect(wrapper.find(Card.Content).children().hasClass(profileStyles.__separated)).toBe(false);
 });
-
-test('renders a StudentCard.Profile with separator class (withSeparatorLine provided)', () => {
-  const wrapper = mount(<StudentCard withSeparatorLine><StudentCard.Profile /></StudentCard>);
-  expect(wrapper.find(Card.Content).children().hasClass(profileStyles.__separated)).toBe(true);
-});


### PR DESCRIPTION
I've moved that lovely line into `Content`, so that the upper part of the card can be extended in an easier way without breaking the layout of the card.

Collaterally, that kind of simplified the card's implementation a little bit, too.