### PR TITLE
Better testing and consistency for <Button />

### DIFF
--- a/src/components/Button/button.jsx
+++ b/src/components/Button/button.jsx
@@ -49,7 +49,7 @@ class Button extends PureComponent {
 
     return <button className={classes}
         disabled={this.props.disabled}
-        onClick={assignOnClick && this._handleButtonClick}
+        onClick={assignOnClick ? this._handleButtonClick : undefined}
         ref={(c) => { this._node = c; }}
         {...this.props.attrs || {}}>
       {this.props.children}

--- a/src/components/Button/button.jsx
+++ b/src/components/Button/button.jsx
@@ -8,15 +8,16 @@ import is from 'is_js';
 import PropTypes from 'prop-types';
 
 class Button extends PureComponent {
-  _handleButtonClick(e) {
-    if (this.props.disabled) {
-      return;
-    }
+  constructor(props) {
+    super(props);
+    this._handleButtonClick = this._handleButtonClick.bind(this);
+  }
 
-    if (is.function(this.props.onClick)) {
-      const ret = this.props.onClick(e);
-      this._setActiveClassOnClick(ret);
-    }
+  _handleButtonClick(e) {
+    if (this.props.disabled) return;
+    const { onClick } = this.props;
+    const ret = is.function(onClick) && onClick(e);
+    this._setActiveClassOnClick(ret);
   }
 
   _setActiveClassOnClick(ret) {
@@ -43,12 +44,12 @@ class Button extends PureComponent {
     this._node.classList.remove(styles.__active);
   }
 
-  _renderButton(type, modeClasses) {
+  _renderButton(type, modeClasses, assignOnClick = true) {
     const classes = classnames(type, modeClasses, this.props.className);
 
     return <button className={classes}
         disabled={this.props.disabled}
-        onClick={this.props.onClick && ((e) => { this._handleButtonClick(e); })}
+        onClick={assignOnClick && this._handleButtonClick}
         ref={(c) => { this._node = c; }}
         {...this.props.attrs || {}}>
       {this.props.children}
@@ -73,8 +74,8 @@ class Button extends PureComponent {
       return <a href={! props.disabled ? props.linkHref : 'javascript:void(0)'}
           className={classnames(styles.ButtonLink, modeClasses, props.className)}
           target={props.newTab ? '_blank' : undefined}
-          onClick={() => { this._setActiveClassOnClick(); }}>
-        {this._renderButton(type, modeClasses)}
+          onClick={this._handleButtonClick}>
+        {this._renderButton(type, modeClasses, false)}
       </a>;
     }
 
@@ -83,8 +84,8 @@ class Button extends PureComponent {
       return <Link to={props.linkTo}
           draggable={false}
           className={classnames(styles.ButtonLink, modeClasses, props.className)}
-          onClick={() => { this._setActiveClassOnClick(); }}>
-        {this._renderButton(type, modeClasses)}
+          onClick={this._handleButtonClick}>
+        {this._renderButton(type, modeClasses, false)}
       </Link>;
     }
 

--- a/src/components/Button/button.spec.jsx
+++ b/src/components/Button/button.spec.jsx
@@ -21,22 +21,6 @@ test('renders its children', () => {
   expect(wrapper.contains(<div id="innerContent" />)).toBe(true);
 });
 
-test('renders a Link when linkTo is provided', () => {
-  const wrapper = shallow(<Button linkTo="/" />);
-  expect(wrapper.find(Link)).toHaveLength(1);
-});
-
-test('renders an <a> when linkTo is provided but disabled=true', () => {
-  const wrapper = shallow(<Button linkTo="/" disabled />);
-  expect(wrapper.find(Link)).toHaveLength(0);
-  expect(wrapper.find('a')).toHaveLength(1);
-});
-
-test('will open link in a new Tab if newTab is provided', () => {
-  const wrapper = shallow(<Button linkHref="/" newTab />);
-  expect(wrapper.prop('target')).toBe('_blank');
-});
-
 test('thows error if invalid type is passed', () => {
   expect(() => shallow(<Button type="faketype" />)).toThrowError();
 });
@@ -61,111 +45,135 @@ test('uses block styles if block property is provided', () => {
   expect(wrapper.find(`.${styles.__block}`).length).toBe(1);
 });
 
-test('uses block styles on Link and itself if block propery is provided', () => {
-  const wrapper = shallow(<Button linkTo="/" block />);
-  expect(wrapper.find(`.${styles.__block}`).length).toBe(2);
-});
-
 test('applies custom attrs when provided', () => {
   const wrapper = shallow(<Button attrs={{ type: 'submit' }} />);
   expect(wrapper.find('button[type="submit"]').length).toBe(1);
 });
 
-describe('when clicked', () => {
+describe('when it should be rendered as a <button />', () => {
   testButtonClick();
+});
 
-  describe('when it renders as an <a />', () => {
-    testButtonClick({ linkHref: '/' });
+describe('when it should be rendered as an <a />', () => {
+  test('renders an <a> when linkTo is provided but disabled=true', () => {
+    const wrapper = shallow(<Button linkTo="/" disabled />);
+    expect(wrapper.find(Link)).toHaveLength(0);
+    expect(wrapper.find('a')).toHaveLength(1);
   });
 
-  describe('when it renders as an <Link />', () => {
-    testButtonClick({ linkTo: '/' });
+  test('renders an <a> when linkHref is provided', () => {
+    const wrapper = shallow(<Button linkHref="/" />);
+    expect(wrapper.find(Link)).toHaveLength(0);
+    expect(wrapper.find('a')).toHaveLength(1);
   });
+
+  test('will open link in a new Tab if newTab is provided', () => {
+    const wrapper = shallow(<Button linkHref="/" newTab />);
+    expect(wrapper.prop('target')).toBe('_blank');
+  });
+
+  testButtonClick({ linkHref: '/' });
+});
+
+describe('when it should be rendered as a <Link />', () => {
+  test('renders a Link when linkTo is provided', () => {
+    const wrapper = shallow(<Button linkTo="/" />);
+    expect(wrapper.find(Link)).toHaveLength(1);
+  });
+
+  test('uses block styles on Link and itself if block propery is provided', () => {
+    const wrapper = shallow(<Button linkTo="/" block />);
+    expect(wrapper.find(`.${styles.__block}`).length).toBe(2);
+  });
+
+  testButtonClick({ linkTo: '/' });
 });
 
 function testButtonClick(props = {}) {
-  test('calls onClick', () => {
-    const onClick = jest.fn();
-    const wrapper = shallow(<Button {...props} onClick={onClick} />);
-    wrapper.simulate('click');
-    expect(onClick).toHaveBeenCalled();
-  });
+  describe('when clicked', () => {
+    test('calls onClick', () => {
+      const onClick = jest.fn();
+      const wrapper = shallow(<Button {...props} onClick={onClick} />);
+      wrapper.simulate('click');
+      expect(onClick).toHaveBeenCalled();
+    });
 
-  test('does not fail if onClick is not provided', () => {
-    const wrapper = shallow(<Button {...props} />);
-    expect(() => wrapper.simulate('click')).not.toThrowError();
-  });
+    test('does not fail if onClick is not provided', () => {
+      const wrapper = shallow(<Button {...props} />);
+      expect(() => wrapper.simulate('click')).not.toThrowError();
+    });
 
-  test('does nothing if it is disabled', () => {
-    const onClick = jest.fn();
-    const wrapper = shallow(<Button {...props} onClick={onClick} disabled />);
-    wrapper.simulate('click');
-    expect(onClick).not.toHaveBeenCalled();
-  });
+    test('does nothing if it is disabled', () => {
+      const onClick = jest.fn();
+      const wrapper = shallow(<Button {...props} onClick={onClick} disabled />);
+      wrapper.simulate('click');
+      expect(onClick).not.toHaveBeenCalled();
+    });
 
-  test('does not fail if the component is unmounted while active', () => {
-    const onClick = jest.fn();
-    const wrapper = mount(<Button {...props} onClick={onClick} onClickActiveClassAddDelay={0} />);
-    wrapper.simulate('click');
-    jest.runTimersToTime(100);
-    wrapper.unmount();
-    expect(() => jest.runOnlyPendingTimers(1000)).not.toThrow();
-  });
+    test('does not fail if the component is unmounted while active', () => {
+      const onClick = jest.fn();
+      const wrapper = mount(<Button {...props} onClick={onClick} onClickActiveClassAddDelay={0} />);
+      wrapper.simulate('click');
+      jest.runTimersToTime(100);
+      wrapper.unmount();
+      expect(() => jest.runOnlyPendingTimers(1000)).not.toThrow();
+    });
 
-  test('sets the .__active class after 100ms by default', () => {
-    jest.useFakeTimers();
+    test('sets the .__active class after 100ms by default', () => {
+      jest.useFakeTimers();
 
-    const wrapper = mount(<Button {...props} onClick={() => {}} />);
-    wrapper.simulate('click');
-    jest.runTimersToTime(100);
+      const wrapper = mount(<Button {...props} onClick={() => {}} />);
+      wrapper.simulate('click');
+      jest.runTimersToTime(100);
 
-    expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
-  });
+      expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
+    });
 
-  test('sets the .__active class after a custom amount of time if onClickActiveClassAddDelay is provided', () => {
-    jest.useFakeTimers();
+    test('sets the .__active class after a custom amount of time if onClickActiveClassAddDelay is provided', () => {
+      jest.useFakeTimers();
 
-    const wrapper = mount(<Button {...props}
-        onClick={() => {}}
-        onClickActiveClassAddDelay={500} />);
-    wrapper.simulate('click');
-    jest.runTimersToTime(100);
-    expect(wrapper.find(`.${styles.__active}`)).toHaveLength(0);
-    jest.runTimersToTime(400);
-    expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
-  });
+      const wrapper = mount(<Button {...props}
+          onClick={() => {}}
+          onClickActiveClassAddDelay={500} />);
+      wrapper.simulate('click');
+      jest.runTimersToTime(100);
+      expect(wrapper.find(`.${styles.__active}`)).toHaveLength(0);
+      jest.runTimersToTime(400);
+      expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
+    });
 
-  test('removes the .__active class when onClick promise is resolved', async () => {
-    jest.useFakeTimers();
+    test('removes the .__active class when onClick promise is resolved', async () => {
+      jest.useFakeTimers();
 
-    let resolve;
-    const promise = new Promise((r) => { resolve = r; });
-    const wrapper = mount(<Button {...props} onClick={() => promise} />);
+      let resolve;
+      const promise = new Promise((r) => { resolve = r; });
+      const wrapper = mount(<Button {...props} onClick={() => promise} />);
 
-    wrapper.simulate('click');
-    jest.runTimersToTime(100);
-    expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
+      wrapper.simulate('click');
+      jest.runTimersToTime(100);
+      expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
 
-    resolve();
-    await promise;
+      resolve();
+      await promise;
 
-    expect(wrapper.find(`.${styles.__active}`)).toHaveLength(0);
-  });
+      expect(wrapper.find(`.${styles.__active}`)).toHaveLength(0);
+    });
 
-  test('removes the .__active class when onClick promise is rejected', async () => {
-    jest.useFakeTimers();
+    test('removes the .__active class when onClick promise is rejected', async () => {
+      jest.useFakeTimers();
 
-    let reject;
-    const promise = new Promise((_, r) => { reject = r; });
-    const wrapper = mount(<Button {...props} onClick={() => promise} />);
+      let reject;
+      const promise = new Promise((_, r) => { reject = r; });
+      const wrapper = mount(<Button {...props} onClick={() => promise} />);
 
-    wrapper.simulate('click');
-    jest.runTimersToTime(100);
-    expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
+      wrapper.simulate('click');
+      jest.runTimersToTime(100);
+      expect(wrapper.find(`.${styles.__active}`)).toHaveLength(1);
 
-    reject();
-    try { await promise; } catch (e) { /**/ }
+      reject();
+      try { await promise; } catch (e) { /**/ }
 
-    expect(wrapper.find(`.${styles.__active}`)).toHaveLength(0);
+      expect(wrapper.find(`.${styles.__active}`)).toHaveLength(0);
+    });
   });
 }


### PR DESCRIPTION
- Added tons of tests, covering different scenarios of the button being clicked and the `__active` class being applied or removed. They are run against the three kinds of buttons that we render.
- All types of buttons use `_handleButtonClick`.
- All types of buttons support their `onClick` returning a promise in the same way.
- The inner `<button />` inside `<Link />` and `<a />` will **not** be passed an `onClick` prop, since its parent is already taking care of that.