### PR TITLE
Our logging strategy is now based on the config instead of the build type

### DIFF
--- a/src/domain/createLoggerMiddleware/index.js
+++ b/src/domain/createLoggerMiddleware/index.js
@@ -1,20 +1,22 @@
 import { createLogger } from 'redux-logger';
 import log from 'domain/log';
+import Config from 'domain/Config';
+import is from 'is_js';
 
 export function createLoggerMiddleware() {
-  if (PRODUCTION) {
-    return () => (next) => (action) => {
-      try {
-        log.debug('Dispatched action:', JSON.stringify(action, null, 2));
-      } catch (e) {
-        log.warn('Could not log action:', e);
-      }
-
-      return next(action);
-    };
+  if (is.not.string(Config.get('sentryDsn')) || is.empty(Config.get('sentryDsn'))) {
+    return createLogger();
   }
 
-  return createLogger();
+  return () => (next) => (action) => {
+    try {
+      log.debug('Dispatched action:', JSON.stringify(action, null, 2));
+    } catch (e) {
+      log.warn('Could not log action:', e);
+    }
+
+    return next(action);
+  };
 }
 
 export default createLoggerMiddleware;

--- a/src/domain/createLoggerMiddleware/index.js
+++ b/src/domain/createLoggerMiddleware/index.js
@@ -1,10 +1,10 @@
 import { createLogger } from 'redux-logger';
 import log from 'domain/log';
 import Config from 'domain/Config';
-import is from 'is_js';
 
 export function createLoggerMiddleware() {
-  if (is.not.string(Config.get('sentryDsn')) || is.empty(Config.get('sentryDsn'))) {
+  const sentry = Config.get('sentry');
+  if (sentry && sentry.disabled === true) {
     return createLogger();
   }
 

--- a/src/domain/createLoggerMiddleware/spec.js
+++ b/src/domain/createLoggerMiddleware/spec.js
@@ -1,19 +1,25 @@
-import { createLoggerMiddleware } from './';
-import { createLogger } from 'redux-logger';
-import log from 'domain/log';
+let Config;
+let log;
+let createLoggerMiddleware;
+let createLogger;
 
 jest.mock('redux-logger', () => ({ createLogger: jest.fn() }));
 jest.mock('domain/log', () => ({ debug: jest.fn(), warn: jest.fn() }));
 
 beforeEach(() => {
-  jest.resetAllMocks();
+  jest.resetModules();
+
+  Config = require('domain/Config');
+  log = require('domain/log');
+  createLoggerMiddleware = require('./').createLoggerMiddleware;
+  createLogger = require('redux-logger').createLogger;
 });
 
-describe('when PRODUCTION=true', () => {
+describe('when the config contains a sentryDsn', () => {
   let next;
 
   beforeEach(() => {
-    global.PRODUCTION = true;
+    Config.merge({ sentryDsn: 'this is a valid dsn' });
     next = jest.fn();
   });
 
@@ -40,9 +46,9 @@ describe('when PRODUCTION=true', () => {
   });
 });
 
-describe('when PRODUCTION=false', () => {
+describe('when the config does not contain a sentryDsn', () => {
   beforeEach(() => {
-    global.PRODUCTION = false;
+    Config.remove('sentryDsn');
   });
 
   test('uses redux-logger directly', () => {

--- a/src/domain/createLoggerMiddleware/spec.js
+++ b/src/domain/createLoggerMiddleware/spec.js
@@ -10,11 +10,11 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe('when the config contains a sentryDsn', () => {
+describe('when the config does not explicitly disable Sentry', () => {
   let next;
 
   beforeEach(() => {
-    Config.merge({ sentryDsn: 'this is a valid dsn' });
+    Config.remove('sentry');
     next = jest.fn();
   });
 
@@ -41,9 +41,9 @@ describe('when the config contains a sentryDsn', () => {
   });
 });
 
-describe('when the config does not contain a sentryDsn', () => {
+describe('when the config explicitly disables Sentry', () => {
   beforeEach(() => {
-    Config.remove('sentryDsn');
+    Config.set('sentry', { disabled: true });
   });
 
   test('uses redux-logger directly', () => {

--- a/src/domain/createLoggerMiddleware/spec.js
+++ b/src/domain/createLoggerMiddleware/spec.js
@@ -1,18 +1,13 @@
-let Config;
-let log;
-let createLoggerMiddleware;
-let createLogger;
+import { createLoggerMiddleware } from './';
+import { createLogger } from 'redux-logger';
+import log from 'domain/log';
+import Config from 'domain/Config';
 
 jest.mock('redux-logger', () => ({ createLogger: jest.fn() }));
 jest.mock('domain/log', () => ({ debug: jest.fn(), warn: jest.fn() }));
 
 beforeEach(() => {
-  jest.resetModules();
-
-  Config = require('domain/Config');
-  log = require('domain/log');
-  createLoggerMiddleware = require('./').createLoggerMiddleware;
-  createLogger = require('redux-logger').createLogger;
+  jest.resetAllMocks();
 });
 
 describe('when the config contains a sentryDsn', () => {

--- a/src/domain/log/index.js
+++ b/src/domain/log/index.js
@@ -1,6 +1,5 @@
 import buildLogToRaven from './buildLogToRaven';
 import Config from 'domain/Config';
-import is from 'is_js';
 
 class log {}
 const methods = ['error', 'info', 'log', 'warn', 'debug'];
@@ -10,7 +9,8 @@ methods.forEach((method) => {
 });
 
 function buildLogMethod(method) {
-  if (is.not.string(Config.get('sentryDsn')) || is.empty(Config.get('sentryDsn'))) {
+  const sentry = Config.get('sentry');
+  if (sentry && sentry.disabled === true) {
     return (...args) => {
       /* eslint-disable no-console */
       if (window.console && console[method]) {

--- a/src/domain/log/index.js
+++ b/src/domain/log/index.js
@@ -1,4 +1,6 @@
 import buildLogToRaven from './buildLogToRaven';
+import Config from 'domain/Config';
+import is from 'is_js';
 
 class log {}
 const methods = ['error', 'info', 'log', 'warn', 'debug'];
@@ -8,7 +10,7 @@ methods.forEach((method) => {
 });
 
 function buildLogMethod(method) {
-  if (! PRODUCTION) {
+  if (is.not.string(Config.get('sentryDsn')) || is.empty(Config.get('sentryDsn'))) {
     return (...args) => {
       /* eslint-disable no-console */
       if (window.console && console[method]) {

--- a/src/domain/log/spec.js
+++ b/src/domain/log/spec.js
@@ -1,26 +1,81 @@
-import log from './';
+let log;
+let Config;
+let buildLogToRaven;
 
-test('is a class', () => {
-  expect(log.prototype).toBeDefined();
+jest.mock('./buildLogToRaven', () => {
+  const mock = jest.fn();
+  return () => mock;
 });
 
-testMethod('error');
-testMethod('info');
-testMethod('log');
-testMethod('warn');
-testMethod('debug');
-
-test('does not crash if there is no "console"', () => {
-  const originalConsole = window.console;
-  delete window.console;
-
-  expect(() => log.debug('some text')).not.toThrowError();
-
-  window.console = originalConsole;
+beforeEach(() => {
+  jest.resetModules();
+  global.console.error = jest.fn();
 });
 
-function testMethod(method) {
-  test(`has a "${method}" method`, () => {
-    expect(typeof log[method]).toBe('function');
+describe('when the config contains a sentryDsn', () => {
+  beforeEach(() => {
+    buildLogToRaven = require('./buildLogToRaven');
+    Config = require('domain/Config');
+    Config.merge({ sentryDsn: 'this is a valid dsn' });
+    log = require('./').default;
   });
+
+  basicTests();
+
+  test('uses the logger returned by buildLogToRaven', () => {
+    log.error('an error');
+    expect(buildLogToRaven()).toHaveBeenCalledWith('an error');
+  });
+
+  test('does not use the console', () => {
+    log.error();
+    expect(global.console.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('when the config does not contain a sentryDsn', () => {
+  beforeEach(() => {
+    buildLogToRaven = require('./buildLogToRaven');
+    Config = require('domain/Config');
+    log = require('./').default;
+  });
+
+  basicTests();
+
+  test('does not the logger returned by buildLogToRaven', () => {
+    log.error('an error');
+    expect(buildLogToRaven()).not.toHaveBeenCalled();
+  });
+
+  test('uses the console', () => {
+    log.error();
+    expect(global.console.error).toHaveBeenCalled();
+  });
+});
+
+function basicTests() {
+  test('is a class', () => {
+    expect(log.prototype).toBeDefined();
+  });
+
+  testMethod('error');
+  testMethod('info');
+  testMethod('log');
+  testMethod('warn');
+  testMethod('debug');
+
+  test('does not crash if there is no "console"', () => {
+    const originalConsole = window.console;
+    delete window.console;
+
+    expect(() => log.debug('some text')).not.toThrowError();
+
+    window.console = originalConsole;
+  });
+
+  function testMethod(method) {
+    test(`has a "${method}" method`, () => {
+      expect(typeof log[method]).toBe('function');
+    });
+  }
 }

--- a/src/domain/log/spec.js
+++ b/src/domain/log/spec.js
@@ -12,11 +12,10 @@ beforeEach(() => {
   global.console.error = jest.fn();
 });
 
-describe('when the config contains a sentryDsn', () => {
+describe('when the config does not explicitly disable Sentry', () => {
   beforeEach(() => {
     buildLogToRaven = require('./buildLogToRaven');
     Config = require('domain/Config');
-    Config.merge({ sentryDsn: 'this is a valid dsn' });
     log = require('./').default;
   });
 
@@ -33,10 +32,11 @@ describe('when the config contains a sentryDsn', () => {
   });
 });
 
-describe('when the config does not contain a sentryDsn', () => {
+describe('when the config explicitly disables Sentry', () => {
   beforeEach(() => {
     buildLogToRaven = require('./buildLogToRaven');
     Config = require('domain/Config');
+    Config.set('sentry', { disabled: true });
     log = require('./').default;
   });
 

--- a/src/setupApp.jsx
+++ b/src/setupApp.jsx
@@ -37,12 +37,15 @@ if (PRODUCTION) {
 Oidc.Log.logger = log;
 Oidc.Log.level = PRODUCTION ? Oidc.Log.WARN : Oidc.Log.INFO;
 
-Raven.config(Config.get('sentryDsn'), {
-  release: COMMIT,
-  environment: Config.get('sentryEnvironment'),
-  tags: { version: VERSION },
-  debug: ! PRODUCTION,
-}).install();
+const sentry = Config.get('sentry');
+if (sentry && sentry.disabled !== true) {
+  Raven.config(sentry.dsn, {
+    release: COMMIT,
+    environment: sentry.environment,
+    tags: { version: VERSION },
+    debug: ! PRODUCTION,
+  }).install();
+}
 
 export function setupApp({ routes, reducer, errorMessageMap }) {
   const { store, syncBrowserHistory } = setupStore(reducer);


### PR DESCRIPTION
There are two logging parts. The main one is `domain/log`, which is the actual logger. Another one is `createLoggerMiddlware`, which takes care of how the Redux actions will be logged.

Previously, both of these things used the `PRODUCTION` global variable. `domain/log` used it to decide whether the browser console or Sentry should be used. `createLoggerMiddlware` used it decide whether the actions should be logged completely (with the whole state included) or not.

This change makes both of the use `Config.get('sentryDsn')` to make those same checks. The benefit of this approach is that the decision of using Sentry or the console is entirely based of whether Sentry is configured for that environment or not. Thus, our QA enviroment (which does not report to Sentry) will log to the browser console after this change, instead of logging to… well, nowhere, which is what it is doing right now.

Additionally, several new tests cases have been added for both `domain/log` and `createLoggerMiddlware`.