### PR TITLE
Avoid CSS class name collisions

### DIFF
--- a/src/containers/Header/NotificationsTray/index.jsx
+++ b/src/containers/Header/NotificationsTray/index.jsx
@@ -14,6 +14,7 @@ import Icon from 'components/Icon';
 import Callout from 'components/Callout';
 import Button from 'components/Button';
 import Checkbox from 'components/Checkbox';
+import testClass from 'domain/testClass';
 
 class NotificationsTray extends PureComponent {
   constructor() {
@@ -85,18 +86,22 @@ class NotificationsTray extends PureComponent {
   }
 
   _renderNotificationCheckbox(notificationId) {
+    const className = classnames(styles.NotificationsTray_notification_checkbox,
+      testClass('notification-checkbox'));
     if (this.state.isMarkingMode) {
       return <Checkbox name={notificationId}
           checked={this.state.notificationIdsToMarkRead.includes(notificationId)}
-          className={styles.NotificationsTray_notification_checkbox}
+          className={className}
           id={notificationId} />;
     }
     return null;
   }
 
   _renderNotification(notification, notificationId) {
+    const className = classnames(styles.NotificationsTray_notification,
+      testClass('notification'));
     return <li>
-      <div className={styles.NotificationsTray_notification}
+      <div className={className}
           onClick={this._onNotificationClicked}
           data-notification-id={notificationId}
           role="button"
@@ -139,6 +144,8 @@ class NotificationsTray extends PureComponent {
   }
 
   _renderNotificationFooter(notifications) {
+    const markBtnClassName = classnames(styles.NotificationsTray_notification_footer_mark,
+      testClass('notification-mark'));
     if (this.state.isMarkingMode) {
       return <div className={styles.NotificationsTray_notification_footer}>
         <label className={styles.NotificationsTray_notification_footer_checkAll}>
@@ -156,7 +163,7 @@ class NotificationsTray extends PureComponent {
             Cancel
           </Button>
           <Button type={Button.Type.primary}
-              className={styles.NotificationsTray_notification_footer_mark}
+              className={markBtnClassName}
               onClick={this._onMarkClick}
               disabled={this.state.notificationIdsToMarkRead.size === 0}>
             Mark
@@ -170,9 +177,9 @@ class NotificationsTray extends PureComponent {
   _renderCalloutPopupContent() {
     const { notifications } = this.props;
     const { viewingNotification } = this.state;
-    const headerBtnClassName = classnames(styles.NotificationsTray_popup_heading_btn, {
-      [styles.__inactive]: !! this.state.isMarkingMode,
-    });
+    const headerBtnClassName = classnames(styles.NotificationsTray_popup_heading_btn,
+      testClass('mark-as-read'),
+      { [styles.__inactive]: !! this.state.isMarkingMode });
     return <div>
       <div className={classnames(styles.NotificationsTray_popup_slide, {
         [styles.__active]: ! this.state.viewingNotification,
@@ -224,11 +231,12 @@ class NotificationsTray extends PureComponent {
 
   render() {
     const { notifications } = this.props;
+    const className = classnames(styles.NotificationsTray, testClass('notifications-tray'));
     return <Callout popupClassName={styles.NotificationsTray_popup}
         content={this._renderCalloutPopupContent()}
         onOpenStateChanged={this._onCalloutOpenStateChanged}
         ref={(comp) => { this._callout = comp; }}>
-      <div className={styles.NotificationsTray}>
+      <div className={className}>
         <Icon className={styles.NotificationsTray_icon}
             id="bell" />
         <CSSTransitionGroup transitionName="bubble"

--- a/webpack/common/webpack.dev.js
+++ b/webpack/common/webpack.dev.js
@@ -11,7 +11,10 @@ module.exports = merge.smart(baseConfigForCommon, {
           {
             loader: 'css-loader',
             options: {
-              localIdentName: '[local]___[hash:base64:5]',
+              getLocalIdent: require('../utils/css-class-hash')({
+                prefix: 'oci-',
+                keepOriginalName: true,
+              }),
             },
           },
         ],

--- a/webpack/common/webpack.prod.js
+++ b/webpack/common/webpack.prod.js
@@ -5,4 +5,22 @@ const uglify = require('../utils/uglify.js');
 module.exports = merge.smart(baseConfigForCommon, {
   devtool: 'cheap-module-source-map',
   plugins: [uglify()],
+  module: {
+    rules: [
+      {
+        test: /\.postcss$/,
+        use: [
+          {
+            loader: 'css-loader',
+            options: {
+              getLocalIdent: require('../utils/css-class-hash')({
+                prefix: 'oci-',
+                keepOriginalName: false,
+              }),
+            },
+          },
+        ],
+      },
+    ],
+  },
 });

--- a/webpack/utils/css-class-hash.js
+++ b/webpack/utils/css-class-hash.js
@@ -1,0 +1,8 @@
+const crypto = require('crypto');
+
+module.exports = ({ prefix = '', keepOriginalName = false }) => (context, localIdentName, localName) => {
+  const className = `${prefix}${localName}`;
+  const hash = crypto.createHash('md5').update(className).digest('hex');
+  if (! keepOriginalName) return `_${hash}`;
+  return `_${className}--${hash.substring(0, 5)}`;
+};


### PR DESCRIPTION
All CSS classes in `omni-common-ui` are prefixed with `oci-` for both the development and production build (before hashing). Thus, we will prevent components that use the same class names from getting their styles messed up.