### PR TITLE
“Home” breadcrumb

### DIFF
--- a/__mocks__/generalMocks.js
+++ b/__mocks__/generalMocks.js
@@ -1,2 +1,3 @@
 jest.mock('/components/Icon/icons');
 jest.mock('/domain/Config');
+jest.mock('/domain/testClass');

--- a/src/components/Breadcrumbs/index.jsx
+++ b/src/components/Breadcrumbs/index.jsx
@@ -8,6 +8,7 @@ import classnames from 'classnames';
 import debounce from 'lodash.debounce';
 import Icon from 'components/Icon';
 import PropTypes from 'prop-types';
+import testClass from 'domain/testClass';
 
 const RESIZE_DEBOUNCE_MS = 100;
 
@@ -134,7 +135,7 @@ class Breadcrumbs extends PureComponent {
           }}>
         {
           itemsToRender.length === 0 ? null :
-          <li className={classnames(styles.Breadcrumbs_crumb, styles.__clickable)}>
+          <li className={classnames(styles.Breadcrumbs_crumb, styles.__clickable, testClass('crumb-home'))}>
             <Link to="/"
                 onClick={() => this._onLinkClick('Home button')}
                 draggable={false}>

--- a/src/components/Breadcrumbs/index.jsx
+++ b/src/components/Breadcrumbs/index.jsx
@@ -98,24 +98,6 @@ class Breadcrumbs extends PureComponent {
     }
   }
 
-  _renderBackButton() {
-    const reversedItems = this.props.items.slice(0).reverse();
-    const backLinkItem = reversedItems.find((item) => item.clickable);
-    let backLinkHref = reversedItems[0].backLinkHref;
-    if (! is.string(backLinkHref)) {
-      if (! is.existy(backLinkItem)) {
-        return null;
-      }
-      backLinkHref = backLinkItem.href;
-    }
-    return <Link to={backLinkHref}
-        className={styles.Breadcrumbs_crumb_back}
-        onClick={() => this._onLinkClick('Back button')}
-        draggable={false}>
-      <Icon id="arrow-left" />
-    </Link>;
-  }
-
   _onLinkClick(linkLabel) {
     ReactGA.event({
       category: 'Navigation',
@@ -152,7 +134,13 @@ class Breadcrumbs extends PureComponent {
           }}>
         {
           itemsToRender.length === 0 ? null :
-          this._renderBackButton()
+          <li className={classnames(styles.Breadcrumbs_crumb, styles.__clickable)}>
+            <Link to="/"
+                onClick={() => this._onLinkClick('Home button')}
+                draggable={false}>
+              <Icon id="home" />
+            </Link>
+          </li>
         }
         {itemsToRender.map((item, idx) => {
           const indexedCrumbClassName = styles[`Breadcrumbs_crumb_${idx}`];

--- a/src/components/Breadcrumbs/spec.jsx
+++ b/src/components/Breadcrumbs/spec.jsx
@@ -21,15 +21,15 @@ beforeEach(() => {
   wrapper = shallow(<Breadcrumbs items={[groupLink, markAttendanceLink]} />);
 });
 
-test('links has been rendered properly', () => {
-  expect(wrapper.find(`.${styles.Breadcrumbs_crumb}`)).toHaveLength(2);
+test('links have been rendered properly', () => {
+  expect(wrapper.find(`.${styles.Breadcrumbs_crumb}`)).toHaveLength(3);
 });
 
-test('back button has been rendered properly', () => {
-  expect(wrapper.find(`.${styles.Breadcrumbs_crumb_back}`)).toHaveLength(1);
+test('home button has been rendered properly', () => {
+  expect(wrapper.find('.test-crumb-home')).toHaveLength(1);
 });
 
 test('only render the first item as a link', () => {
   expect(wrapper.find(`.${styles.Breadcrumbs_crumb}`).last().find('span').text()).toBe('mark attendance');
-  expect(wrapper.find(`.${styles.Breadcrumbs_crumb}`).first().find(Link)).toHaveLength(1);
+  expect(wrapper.find(`.${styles.Breadcrumbs_crumb}`).at(1).find(Link)).toHaveLength(1);
 });

--- a/src/components/Breadcrumbs/style.postcss
+++ b/src/components/Breadcrumbs/style.postcss
@@ -32,6 +32,7 @@
 
   &_crumb {
     & a {
+      display: inline-block;
       text-decoration: none;
     }
 
@@ -42,10 +43,6 @@
 
     &:not(.__clickable) {
       cursor: default;
-    }
-
-    &_back {
-      padding-right: 0.5em;
     }
   }
 

--- a/src/components/Icon/home.svg
+++ b/src/components/Icon/home.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="20px" height="17px" viewBox="0 0 20 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.8.3 (29802) - http://www.bohemiancoding.com/sketch -->
+    <title>home</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="home" fill="#000000">
+            <g id="Home">
+                <g>
+                    <path d="M18.672,10 L17,10 L17,16 C17,16.445 16.806,17 16,17 L12,17 L12,11 L8,11 L8,17 L4,17 C3.194,17 3,16.445 3,16 L3,10 L1.328,10 C0.73,10 0.858,9.676 1.268,9.252 L9.292,1.22 C9.487,1.018 9.743,0.918 10,0.908 C10.257,0.918 10.513,1.017 10.708,1.22 L18.731,9.251 C19.142,9.676 19.27,10 18.672,10 L18.672,10 Z" id="Shape"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/domain/testClass/__mocks__/index.js
+++ b/src/domain/testClass/__mocks__/index.js
@@ -1,0 +1,2 @@
+export const testClass = (klass) => `test-${klass}`;
+export default testClass;

--- a/src/domain/testClass/spec.js
+++ b/src/domain/testClass/spec.js
@@ -3,7 +3,7 @@ let testClass;
 beforeEach(() => {
   jest.resetModules();
   require('domain/Config').merge({ enableTestClasses: true });
-  testClass = require('./').default;
+  testClass = require.requireActual('./').default;
 });
 
 test('throws an error if the given class contains unacceptable characters', () => {


### PR DESCRIPTION
Replaced the previous “back” arrow with a ”home” icon that always takes the user to the root URL.